### PR TITLE
fix: IE 11

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import App from './App.vue'
 import VueRouter from 'vue-router'
+import '@babel/polyfill'
 import SimplePortal, {
   config as PortalConfig,
 } from /*'../src'*/ '../package/dist/index.mjs'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:unit": "vue-cli-service test:unit"
   },
   "devDependencies": {
+    "@babel/polyfill": "^7.4.4",
     "@storybook/addon-actions": "^4.1.0 || ^5.0.0",
     "@storybook/addon-knobs": "^4.1.0 || ^5.0.0",
     "@storybook/addon-links": "^4.1.0 || ^5.0.0",

--- a/src/components/Portal.js
+++ b/src/components/Portal.js
@@ -67,7 +67,7 @@ export default Vue.extend({
       const parent = document.querySelector('body')
       const child = document.createElement(this.tag)
       child.id = this.selector.substring(1)
-      parent.append(child)
+      parent.appendChild(child)
     },
     mount() {
       const targetEl = this.getTargetEl()
@@ -75,7 +75,7 @@ export default Vue.extend({
       if (this.prepend && targetEl.firstChild) {
         targetEl.insertBefore(el, targetEl.firstChild)
       } else {
-        targetEl.append(el)
+        targetEl.appendChild(el)
       }
 
       this.container = new TargetContainer({

--- a/yarn.lock
+++ b/yarn.lock
@@ -674,6 +674,14 @@
     "@babel/helper-regex" "^7.0.0"
     regexpu-core "^4.1.3"
 
+"@babel/polyfill@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
+  integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==
+  dependencies:
+    core-js "^2.6.5"
+    regenerator-runtime "^0.13.2"
+
 "@babel/preset-env@^7.0.0", "@babel/preset-env@^7.3.1":
   version "7.4.2"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.4.2.tgz#2f5ba1de2daefa9dcca653848f96c7ce2e406676"


### PR DESCRIPTION
This PR addresses two issues that we encountered once we entered the portal.

1. The demo does not work on IE (by default). IE complains about promises. **Fix:** In the demo entry point I simply import the babel polyfills. Running `yarn serve --mode production` then works in IE.
2. Vue Simple Portal itself does not work in IE. The demo helped a lot to track that issue down. IE seems not to have support for `append`. So I have replaced it with `appendChild`.

`yarn test` says everything is still okay.

