### PR TITLE
Fix #20

### DIFF
--- a/src/components/TargetContainer.js
+++ b/src/components/TargetContainer.js
@@ -14,7 +14,7 @@ export default Vue.extend({
     const nodes = this.updatedNodes && this.updatedNodes()
     if (!nodes) return h()
     return nodes.length < 2 && !nodes[0].text
-      ? nodes
+      ? h(nodes[0].tag, nodes[0].data, nodes[0].children)
       : h(this.tag || 'DIV', nodes)
   },
   destroyed() {


### PR DESCRIPTION
Not too sure why this works, or rather, why it doesn’t work without this rather strange approach.

Unless I’m mistaken, the correct return value when `nodes.length < 2 && !nodes[0].text` is true should be `nodes[0]` rather than just `nodes` (as `nodes` is an array, not a VNode).

However, returning just `nodes[0]` does not fix the bug where the portal contents don’t render as described in #20. Calling `createElement` on its constituent parts is working, but as far as I can tell, the output of the function and the initial `nodes[0]` VNode are identical. Does a VNode have some sort of affinity its parent component maybe?